### PR TITLE
Fix #62

### DIFF
--- a/VitDeck/Assets/VitDeck/Config.meta
+++ b/VitDeck/Assets/VitDeck/Config.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 942c41123f54e2f40b017e2d4dbd4589
+labels:
+- VitDeck.ConfigFolder
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Config/ProductInfo.asset
+++ b/VitDeck/Assets/VitDeck/Config/ProductInfo.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a424079e73ca2ce4e91c6c9f0d62cf81, type: 3}
+  m_Name: ProductInfo
+  m_EditorClassIdentifier: 
+  version: 1.0.0-dev

--- a/VitDeck/Assets/VitDeck/Config/ProductInfo.asset.meta
+++ b/VitDeck/Assets/VitDeck/Config/ProductInfo.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bac4bb3ff22830b418a8dea9a67747ce
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Main/GUI/InfoWindow.cs
+++ b/VitDeck/Assets/VitDeck/Main/GUI/InfoWindow.cs
@@ -27,7 +27,7 @@ namespace VitDeck.Main.GUI
 
         private void OnEnable()
         {
-            versionLabel = "Version : " + VitDeck.GetVersion();
+            versionLabel = "Version : " + VersionUtility.GetVersion();
 
             JsonReleaseInfo.FetchInfo(releaseURL);
             if (JsonReleaseInfo.GetVersion() == null)

--- a/VitDeck/Assets/VitDeck/Main/Tests/VitDeckTest.cs
+++ b/VitDeck/Assets/VitDeck/Main/Tests/VitDeckTest.cs
@@ -5,11 +5,5 @@ namespace VitDeck.Main.Tests
 {
     public class VitDeckTest
     {
-        [Test]
-        public void TestVitDeckVersion()
-        {
-            string version = VitDeck.GetVersion();
-            Assert.That(VersionUtility.IsSemanticVersioning(version), Is.True);
-        }
     }
 }

--- a/VitDeck/Assets/VitDeck/Main/UpdateCheck.cs
+++ b/VitDeck/Assets/VitDeck/Main/UpdateCheck.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using UnityEngine;
+using VitDeck.Utilities;
 
 namespace VitDeck.Main
 {
@@ -22,7 +23,7 @@ namespace VitDeck.Main
 
         public static bool IsLatest(string releaseUrl)
         {
-            string localVersion = VitDeck.GetVersion();
+            string localVersion = VersionUtility.GetVersion();
             string latestVersion = JsonReleaseInfo.GetVersion();
 
             return string.Equals(localVersion, latestVersion);

--- a/VitDeck/Assets/VitDeck/Main/VitDeck.cs
+++ b/VitDeck/Assets/VitDeck/Main/VitDeck.cs
@@ -5,13 +5,5 @@ namespace VitDeck.Main
     /// </summary>
     public static class VitDeck
     {
-        /// <summary>
-        /// VitDeckのバージョンを返します。
-        /// </summary>
-        /// <returns>実行中のVitDeckのバージョン</returns>
-        public static string GetVersion()
-        {
-            return "0.0.1";
-        }
     }
 }

--- a/VitDeck/Assets/VitDeck/Utilities/AssetUtility.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/AssetUtility.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UnityEditor;
 
 namespace VitDeck.Utilities
@@ -10,13 +11,13 @@ namespace VitDeck.Utilities
     public static class AssetUtility
     {
         private static string _imageFolderPath;
-
+        private static string _configFolderPath;
         /// <summary>
         /// VitDeck用画像フォルダのパス
         /// </summary>
         /// <remarks>
         /// Unityで`ImagesFolder`ラベルが付与されているアセットの一つ目のパスを返す。
-        /// 存在しない場合はExceptionを返す。
+        /// 存在しない場合はDirectoryNotFoundExceptionを返す。
         /// </remarks>
         public static string ImageFolderPath
         {
@@ -24,17 +25,43 @@ namespace VitDeck.Utilities
             {
                 if (string.IsNullOrEmpty(_imageFolderPath))
                 {
-                    string[] imageFolderGUIDs = AssetDatabase.FindAssets("l:VitDeck.ImagesFolder");
-                    if (imageFolderGUIDs != null && imageFolderGUIDs.Length > 0)
-                    {
-                        _imageFolderPath = AssetDatabase.GUIDToAssetPath(imageFolderGUIDs[0]);
-                    }
-                    else
-                    {
-                        throw new DirectoryNotFoundException("Images folder not found.");
-                    }
+                    _imageFolderPath = GetFolderPath("VitDeck.ImagesFolder");
                 }
                 return _imageFolderPath;
+            }
+        }
+        /// <summary>
+        /// 設定ファイル用フォルダのパス
+        /// </summary>
+        /// <remarks>
+        /// Unityでラベルが付与されているアセットの一つ目のパスを返す。
+        /// 存在しない場合はDirectoryNotFoundExceptionを返す。
+        /// </remarks>
+        public static string ConfigFolderPath
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_configFolderPath))
+                {
+                    _configFolderPath = GetFolderPath("VitDeck.ConfigFolder");
+                }
+                return _configFolderPath;
+            }
+        }
+
+        private static string GetFolderPath(string assetLabel)
+        {
+            string folderPath = AssetDatabase.FindAssets("l:" + assetLabel)
+                 .Select(guid => AssetDatabase.GUIDToAssetPath(guid))
+                 .Where(path => path != null)
+                 .FirstOrDefault();
+            if (folderPath != null)
+            {
+                return folderPath;
+            }
+            else
+            {
+                throw new DirectoryNotFoundException(string.Format("folder for {0} not found.", assetLabel));
             }
         }
 

--- a/VitDeck/Assets/VitDeck/Utilities/ProductInfo.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/ProductInfo.cs
@@ -1,0 +1,12 @@
+using System;
+using UnityEngine;
+
+namespace VitDeck.Utilities
+{
+    [CreateAssetMenu]
+    public class ProductInfo : ScriptableObject
+    {
+        [SerializeField]
+        public string version = "";
+    }
+}

--- a/VitDeck/Assets/VitDeck/Utilities/ProductInfo.cs.meta
+++ b/VitDeck/Assets/VitDeck/Utilities/ProductInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a424079e73ca2ce4e91c6c9f0d62cf81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Utilities/Tests/AssetUtilityTest.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/Tests/AssetUtilityTest.cs
@@ -9,5 +9,10 @@ namespace VitDeck.Utilities.Tests
         {
             Assert.That(AssetUtility.ImageFolderPath, Is.EqualTo("Assets/VitDeck/Images"));
         }
+        [Test]
+        public void TestConfigFolderPath()
+        {
+            Assert.That(AssetUtility.ConfigFolderPath, Is.EqualTo("Assets/VitDeck/Config"));
+        }
     }
 }

--- a/VitDeck/Assets/VitDeck/Utilities/Tests/VersionUtilityTest.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/Tests/VersionUtilityTest.cs
@@ -17,5 +17,11 @@ namespace VitDeck.Utilities.Tests
             Assert.That(VersionUtility.IsSemanticVersioning("1.342.1-alpha3.2.3+5260032"), Is.True);
             Assert.That(VersionUtility.IsSemanticVersioning("1.342.1+5260032-alpha3.2.3"), Is.False);
         }
+        [Test]
+        public void TestGetVersion()
+        {
+            var version = VersionUtility.GetVersion();
+            Assert.That(VersionUtility.IsSemanticVersioning(version), Is.True);
+        }
     }
 }

--- a/VitDeck/Assets/VitDeck/Utilities/VersionUtility.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/VersionUtility.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using System.Text.RegularExpressions;
+using UnityEditor;
 
 namespace VitDeck.Utilities
 {
@@ -15,6 +17,16 @@ namespace VitDeck.Utilities
         public static bool IsSemanticVersioning(string version)
         {
             return Regex.IsMatch(version, @"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-\w+(\.\w+)*)?(\+\w+(\.\w+)*)?$");
+        }
+
+        /// <summary>
+        /// バージョン番号を取得する。取得できなかった場合は空文字を返す。
+        /// </summary>
+        /// <returns>バージョン番号</returns>
+        public static string GetVersion()
+        {
+            var productInfo = AssetDatabase.LoadAssetAtPath<ProductInfo>(AssetUtility.ConfigFolderPath + "/ProductInfo.asset");
+            return productInfo != null ? productInfo.version : string.Empty;
         }
     }
 }


### PR DESCRIPTION
#62 の実装です。
`VitDeck.GetVersion`で取得していたバージョン番号を`VersionUtility.GetVersion`で取得するよう変更しました。
ConfigFolderのパスは`AssetUtility.ConfigFolder`で取得できるようになっています。

@sktkkoo アップデート機能周りの使用箇所も変更しています。ご注意ください。

影響箇所テスト済みのため、このままマージします。