### PR TITLE
Feature/#73

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B03_ComponentBlacklistRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B03_ComponentBlacklistRule.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+
+namespace VitDeck.Validator
+{
+    /// <summary>
+    /// 使用可能なコンポーネントをブラックリスト検証する。
+    /// </summary>
+    /// <remarks>リストに載っているコンポーネントが検出された場合にエラーメッセージを出す。</remarks>
+    public class ComponentBlacklistRule : BaseRule
+    {
+        private readonly ComponentReference[] references;
+        /// <summary>
+        /// コンストラクタ。
+        /// </summary>
+        /// <param name="name">ルール名</param>
+        /// <param name="references">コンポーネントのブラックリスト</param>
+        public ComponentBlacklistRule(string name, ComponentReference[] references) : base(name)
+        {
+            this.references = references ?? new ComponentReference[] { };
+        }
+
+        protected override void Logic(ValidationTarget target)
+        {
+            foreach (var obj in target.GetAllObjects())
+            {
+                var components = obj.GetComponents<Component>();
+                foreach (var cmp in components)
+                {
+                    if (cmp.GetType() == typeof(Transform))
+                        continue;
+                    var message = "";
+                    foreach (var reference in references)
+                    {
+                        if (reference != null && reference.Exists(cmp))
+                        {
+                            switch (reference.level)
+                            {
+                                case ValidationLevel.ALLOW:
+                                    break;
+                                case ValidationLevel.NEGOTIABLE:
+                                    message = string.Format("{0}:{1}を使用する場合は事前に運営に問い合わせてください。", reference.name, cmp.GetType().Name);
+                                    AddIssue(new Issue(obj, IssueLevel.Warning, message, string.Empty, string.Empty));
+                                    break;
+                                case ValidationLevel.DISALLOW:
+                                    message = string.Format("{0}:{1}の使用は許可されていません。", reference.name, cmp.GetType().Name);
+                                    AddIssue(new Issue(obj, IssueLevel.Error, message, string.Empty, string.Empty));
+                                    break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B03_ComponentBlacklistRule.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B03_ComponentBlacklistRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c619dd56904f004393087b28abf8105
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/B03_TestComponentBlacklistRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/B03_TestComponentBlacklistRule.cs
@@ -1,0 +1,67 @@
+using NUnit.Framework;
+
+namespace VitDeck.Validator.Test
+{
+    public class TestComponentBlacklistRule
+    {
+        [Test]
+        public void TestValidate()
+        {
+            var grupeName = "カメラ";
+            var rule = new ComponentBlacklistRule("コンポーネントブラックリストルール",
+                            new ComponentReference[] { new ComponentReference("ライティング", new string[] { "UnityEngine.Light" }, ValidationLevel.ALLOW),
+                                                       new ComponentReference(grupeName, new string[] { "UnityEngine.Camera" }, ValidationLevel.NEGOTIABLE),
+                                                       new ComponentReference("Jointの使用禁止", new string[] { "UnityEngine.CharacterJoint",
+                                                                                                                "UnityEngine.ConfigurableJoint",
+                                                                                                                "UnityEngine.FixedJoint",
+                                                                                                                "UnityEngine.HingeJoint",
+                                                                                                                "UnityEngine.SpringJoint"}, ValidationLevel.DISALLOW)});
+            var finder = new ValidationTargetFinder();
+            var target = finder.Find("Assets/VitDeck/Validator/Tests/Data/B03_ComponentBlacklistRule", true);
+            var result = rule.Validate(target);
+            Assert.That(result.RuleName, Is.EqualTo("コンポーネントブラックリストルール"));
+            Assert.That(result.Issues.Count, Is.EqualTo(2));
+            Assert.That(result.Issues[0].level, Is.EqualTo(IssueLevel.Warning));
+            Assert.That(result.Issues[0].target.name, Is.EqualTo("Main Camera"));
+            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("{0}:Cameraを使用する場合は事前に運営に問い合わせてください。", grupeName)));
+            Assert.That(result.Issues[0].solution, Is.Empty);
+            Assert.That(result.Issues[0].solutionURL, Is.Empty);
+            Assert.That(result.Issues[1].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[1].target.name, Is.EqualTo("GameObjectWithJoint"));
+        }
+        [Test]
+        public void TestValidateError()
+        {
+            var grupeName = "カメラ";
+            var rule = new ComponentBlacklistRule("コンポーネントブラックリストルール",
+                new ComponentReference[] { new ComponentReference("ライティング", new string[] { "UnityEngine.Light" }, ValidationLevel.ALLOW),
+                                                       new ComponentReference(grupeName, new string[] { "UnityEngine.Camera" }, ValidationLevel.DISALLOW),
+                                                       new ComponentReference("Jointの使用禁止", new string[] { "UnityEngine.CharacterJoint",
+                                                                                                                "UnityEngine.ConfigurableJoint",
+                                                                                                                "UnityEngine.FixedJoint",
+                                                                                                                "UnityEngine.HingeJoint",
+                                                                                                                "UnityEngine.SpringJoint"}, ValidationLevel.DISALLOW)});
+            var finder = new ValidationTargetFinder();
+            var target = finder.Find("Assets/VitDeck/Validator/Tests/Data/B03_ComponentBlacklistRule", true);
+            var result = rule.Validate(target);
+            Assert.That(result.Issues.Count, Is.EqualTo(2));
+            Assert.That(result.Issues[0].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[0].target.name, Is.EqualTo("Main Camera"));
+            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("{0}:{1}の使用は許可されていません。", grupeName, "Camera")));
+            Assert.That(result.Issues[0].solution, Is.Empty);
+            Assert.That(result.Issues[0].solutionURL, Is.Empty);
+        }
+        [Test]
+        public void TestValidateInvalidSetting()
+        {
+            var invalidRule = new ComponentBlacklistRule(null, new ComponentReference[] { null });
+            var invalidRule2 = new ComponentBlacklistRule("コンポーネントブラックリストルール", null);
+            var finder = new ValidationTargetFinder();
+            var target = finder.Find("Assets/VitDeck/Validator/Tests/Data/B03_ComponentBlacklistRule", true);
+            var result = invalidRule.Validate(target);
+            Assert.That(result.Issues.Count, Is.EqualTo(0));
+            var failResult = invalidRule2.Validate(target);
+            Assert.That(result.Issues.Count, Is.EqualTo(0));
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/B03_TestComponentBlacklistRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/B03_TestComponentBlacklistRule.cs
@@ -61,7 +61,7 @@ namespace VitDeck.Validator.Test
             var result = invalidRule.Validate(target);
             Assert.That(result.Issues.Count, Is.EqualTo(0));
             var failResult = invalidRule2.Validate(target);
-            Assert.That(result.Issues.Count, Is.EqualTo(0));
+            Assert.That(failResult.Issues.Count, Is.EqualTo(0));
         }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Tests/B03_TestComponentBlacklistRule.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/B03_TestComponentBlacklistRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61c59e181f521054fb52653d8142f392
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B03_ComponentBlacklistRule.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B03_ComponentBlacklistRule.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e0c82b5da1ead7b4fa67cb4084f405c8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B03_ComponentBlacklistRule/B03_ComponentBlacklistRule.unity
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B03_ComponentBlacklistRule/B03_ComponentBlacklistRule.unity
@@ -1,0 +1,373 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 8
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 9
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &540229237
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 540229239}
+  - component: {fileID: 540229238}
+  m_Layer: 0
+  m_Name: GameObjectNotListed
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!223 &540229238
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 540229237}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &540229239
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 540229237}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -5.220272}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 1.7681274, y: -3.3660069}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &742567707
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 742567710}
+  - component: {fileID: 742567709}
+  - component: {fileID: 742567708}
+  m_Layer: 0
+  m_Name: GameObjectWithJoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!138 &742567708
+FixedJoint:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 742567707}
+  m_ConnectedBody: {fileID: 0}
+  m_BreakForce: Infinity
+  m_BreakTorque: Infinity
+  m_EnableCollision: 0
+  m_EnablePreprocessing: 1
+  m_MassScale: 1
+  m_ConnectedMassScale: 1
+--- !u!54 &742567709
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 742567707}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!4 &742567710
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 742567707}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.7681274, y: -3.3660069, z: -5.220272}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1181681521
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1181681525}
+  - component: {fileID: 1181681524}
+  - component: {fileID: 1181681523}
+  - component: {fileID: 1181681522}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1181681522
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1181681521}
+  m_Enabled: 1
+--- !u!124 &1181681523
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1181681521}
+  m_Enabled: 1
+--- !u!20 &1181681524
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1181681521}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1181681525
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1181681521}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1848687056
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1848687058}
+  - component: {fileID: 1848687057}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1848687057
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1848687056}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1848687058
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1848687056}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B03_ComponentBlacklistRule/B03_ComponentBlacklistRule.unity.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B03_ComponentBlacklistRule/B03_ComponentBlacklistRule.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0397c0bed99360848b907823339bb80b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#73 ComponentBlacklistRule の実装です。
#84 と共通のComponentReferenceクラスを使用してブラックリスト検証します。
リストに該当しないコンポーネントは無視します。

ComponentBlacklistRule |  コンポーネント有無 |   |  
-- | -- | -- | --
level | Exists:true | Exists:false |  メッセージ
ALLOW（設定の意味なし） | パス | パス |  
NEGOTIATABLE | 要交渉メッセージ | パス | {0}を使用する場合は事前に運営に問い合わせてください。
DISALLOW | 禁止メッセージ | パス | {0}の使用は許可されていません。

