### PR TITLE
Feature/#102

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Tests/TestValidator.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/TestValidator.cs
@@ -34,7 +34,7 @@ namespace VitDeck.Validator.Test
             Assert.That(results[0].Issues[0].solution, Is.EqualTo(""));
             Assert.That(results[0].Issues[0].solutionURL, Is.EqualTo(""));
             //Validate中の例外
-            results = Validator.Validate(ruleSet, "Assets/VitDeck/Validator/Tests/Validate");
+            results = Validator.Validate(ruleSet, "Assets/VitDeck/Validator/Tests/Validate", true);
             LogAssert.Expect(LogType.Error, new Regex(@"ルールチェックを中断しました:テスト用の例外"));
         }
         [Test]

--- a/VitDeck/Assets/VitDeck/Validator/Validator.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Validator.cs
@@ -48,6 +48,7 @@ namespace VitDeck.Validator
                     break;
                 }
             }
+            Undo.RevertAllInCurrentGroup();
             return results.ToArray();
         }
 

--- a/VitDeck/Assets/VitDeck/Validator/Validator.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Validator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using UnityEditor;
 using UnityEngine;
 using VitDeck.Utilities;
 
@@ -23,6 +24,7 @@ namespace VitDeck.Validator
             try
             {
                 target = ruleSet.TargetFinder.Find(baseFolder, forceOpenScene);
+                RegisterUndo(target);
             }
             catch (FatalValidationErrorException e)
             {
@@ -47,6 +49,12 @@ namespace VitDeck.Validator
                 }
             }
             return results.ToArray();
+        }
+
+        private static void RegisterUndo(ValidationTarget target)
+        {
+            foreach (var rootObject in target.GetRootObjects())
+                Undo.RegisterFullObjectHierarchyUndo(rootObject, "Validate");
         }
 
         public static IRuleSet[] GetRuleSets()


### PR DESCRIPTION
#102 Undoの部分的な実装
検証開始時にシーン上のオブジェクトをUndoの記録対象に登録しておく。
これにより、検証により不慮の変更が発生した場合でもUndoが可能になる。

制限：
- ゲームオブジェクトの追加には対応できない。
- 変更の中身がない場合でもUndoの履歴に「Validate」が残ってしまう。