### PR TITLE
Featurer/#74

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs
@@ -42,7 +42,6 @@ namespace VitDeck.Validator
                     {
                         AddIssue(new Issue(obj, IssueLevel.Error, string.Format("オブジェクト({0})でシェーダーエラーが検出されました。", obj.name), string.Empty, string.Empty));
                     }
-
                 }
             }
         }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs
@@ -1,0 +1,42 @@
+﻿using UnityEngine;
+using System.Linq;
+
+namespace VitDeck.Validator
+{
+    /// <summary>
+    /// エラーシェーダーの検出ルール
+    /// </summary>
+    /// <remarks>シェーダーエラーの存在するオブジェクトを検出する。</remarks>
+    public class ErrorShaderRule : BaseRule
+    {
+        /// <summary>
+        /// コンストラクタ。
+        /// </summary>
+        /// <param name="name">ルール名</param>
+        public ErrorShaderRule(string name) : base(name) { }
+
+        protected override void Logic(ValidationTarget target)
+        {
+            foreach (var obj in target.GetAllObjects())
+            {
+                if (obj.GetComponent<Renderer>() == null)
+                    continue;
+
+                var materials = obj.GetComponent<Renderer>().sharedMaterials;
+
+                foreach (var material in materials)
+                {
+                    if (material == null)
+                    {
+                        continue;
+                    }
+
+                    if (material.shader.name == "Hidden/InternalErrorShader" || material.shader.name == string.Empty || material.shader.name == null)
+                    {
+                        AddIssue(new Issue(obj, IssueLevel.Error, string.Format("シェーダエラーが存在するオブジェクト({0})があります。", obj.name), string.Empty, string.Empty));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs
@@ -28,13 +28,21 @@ namespace VitDeck.Validator
                 {
                     if (material == null)
                     {
+                        AddIssue(new Issue(obj, IssueLevel.Error, string.Format("オブジェクト({0})のRendererにマテリアルの参照がありません。", obj.name), string.Empty, string.Empty));
                         continue;
                     }
 
-                    if (material.shader.name == "Hidden/InternalErrorShader" || material.shader.name == string.Empty || material.shader.name == null)
+                    if (material.shader.name == "Hidden/InternalErrorShader")
                     {
-                        AddIssue(new Issue(obj, IssueLevel.Error, string.Format("シェーダエラーが存在するオブジェクト({0})があります。", obj.name), string.Empty, string.Empty));
+                        AddIssue(new Issue(obj, IssueLevel.Error, string.Format("オブジェクト({0})のマテリアルで正しいシェーダーが参照されていません。", obj.name), string.Empty, string.Empty));
+                        continue;
                     }
+
+                    if (material.shader.name == string.Empty || material.shader.name == null)
+                    {
+                        AddIssue(new Issue(obj, IssueLevel.Error, string.Format("オブジェクト({0})でシェーダーエラーが検出されました。", obj.name), string.Empty, string.Empty));
+                    }
+
                 }
             }
         }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs
@@ -40,7 +40,7 @@ namespace VitDeck.Validator
 
                     if (material.shader.name == string.Empty || material.shader.name == null)
                     {
-                        AddIssue(new Issue(obj, IssueLevel.Error, string.Format("オブジェクト({0})でシェーダーエラーが検出されました。", obj.name), string.Empty, string.Empty));
+                        AddIssue(new Issue(obj, IssueLevel.Error, "オブジェクトでシェーダーエラーが検出されました。", string.Empty, string.Empty));
                     }
                 }
             }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs
@@ -28,7 +28,7 @@ namespace VitDeck.Validator
                 {
                     if (material == null)
                     {
-                        AddIssue(new Issue(obj, IssueLevel.Error, string.Format("オブジェクト({0})のRendererにマテリアルの参照がありません。", obj.name), string.Empty, string.Empty));
+                        AddIssue(new Issue(obj, IssueLevel.Info, "オブジェクトのRendererにマテリアルの参照がありません。", string.Empty, string.Empty));
                         continue;
                     }
 

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs
@@ -34,7 +34,7 @@ namespace VitDeck.Validator
 
                     if (material.shader.name == "Hidden/InternalErrorShader")
                     {
-                        AddIssue(new Issue(obj, IssueLevel.Error, string.Format("オブジェクト({0})のマテリアルで正しいシェーダーが参照されていません。", obj.name), string.Empty, string.Empty));
+                        AddIssue(new Issue(obj, IssueLevel.Error, "オブジェクトのマテリアルで正しいシェーダーが参照されていません。", string.Empty, string.Empty));
                         continue;
                     }
 

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B04_ErrorShaderRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09d992155ae59f542b1dbdce2feb3fc2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/B04_TestErrorShaderRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/B04_TestErrorShaderRule.cs
@@ -17,17 +17,17 @@ namespace VitDeck.Validator.Test
             Assert.That(result.Issues.Count, Is.EqualTo(3));
             Assert.That(result.Issues[0].level, Is.EqualTo(IssueLevel.Error));
             Assert.That(result.Issues[0].target.name, Is.EqualTo("HiddenInternalErrorShaderObject"));
-            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("オブジェクト({0})のマテリアルで正しいシェーダーが参照されていません。", "HiddenInternalErrorShaderObject")));
+            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("オブジェクトのマテリアルで正しいシェーダーが参照されていません。", "HiddenInternalErrorShaderObject")));
             Assert.That(result.Issues[0].solution, Is.Empty);
             Assert.That(result.Issues[0].solutionURL, Is.Empty);
             Assert.That(result.Issues[1].level, Is.EqualTo(IssueLevel.Error));
             Assert.That(result.Issues[1].target.name, Is.EqualTo("ErrorShaderObject"));
-            Assert.That(result.Issues[1].message, Is.EqualTo(string.Format("オブジェクト({0})でシェーダーエラーが検出されました。", "ErrorShaderObject")));
+            Assert.That(result.Issues[1].message, Is.EqualTo(string.Format("オブジェクトでシェーダーエラーが検出されました。", "ErrorShaderObject")));
             Assert.That(result.Issues[1].solution, Is.Empty);
             Assert.That(result.Issues[1].solutionURL, Is.Empty);
-            Assert.That(result.Issues[2].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[2].level, Is.EqualTo(IssueLevel.Info));
             Assert.That(result.Issues[2].target.name, Is.EqualTo("NoneMaterialObject"));
-            Assert.That(result.Issues[2].message, Is.EqualTo(string.Format("オブジェクト({0})のRendererにマテリアルの参照がありません。", "NoneMaterialObject")));
+            Assert.That(result.Issues[2].message, Is.EqualTo(string.Format("オブジェクトのRendererにマテリアルの参照がありません。", "NoneMaterialObject")));
             Assert.That(result.Issues[2].solution, Is.Empty);
             Assert.That(result.Issues[2].solutionURL, Is.Empty);
         }

--- a/VitDeck/Assets/VitDeck/Validator/Tests/B04_TestErrorShaderRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/B04_TestErrorShaderRule.cs
@@ -1,0 +1,30 @@
+﻿using UnityEngine;
+using NUnit.Framework;
+using UnityEditor;
+
+namespace VitDeck.Validator.Test
+{
+    public class TestErrorShaderRule
+    {
+        [Test]
+        public void TestValidate()
+        {
+            var finder = new ValidationTargetFinder();
+            var target = finder.Find("Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule", true);
+            var rule = new ErrorShaderRule("エラーシェーダー検出");
+            var result = rule.Validate(target);
+            Assert.That(result.RuleName, Is.EqualTo("エラーシェーダー検出"));
+            Assert.That(result.Issues.Count, Is.EqualTo(2));
+            Assert.That(result.Issues[0].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[0].target.name, Is.EqualTo("HiddenInternalErrorShaderObject"));
+            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("シェーダエラーが存在するオブジェクト({0})があります。", "HiddenInternalErrorShaderObject")));
+            Assert.That(result.Issues[0].solution, Is.Empty);
+            Assert.That(result.Issues[0].solutionURL, Is.Empty);
+            Assert.That(result.Issues[1].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[1].target.name, Is.EqualTo("ErrorShaderObject"));
+            Assert.That(result.Issues[1].message, Is.EqualTo(string.Format("シェーダエラーが存在するオブジェクト({0})があります。", "ErrorShaderObject")));
+            Assert.That(result.Issues[1].solution, Is.Empty);
+            Assert.That(result.Issues[1].solutionURL, Is.Empty);
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/B04_TestErrorShaderRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/B04_TestErrorShaderRule.cs
@@ -14,17 +14,22 @@ namespace VitDeck.Validator.Test
             var rule = new ErrorShaderRule("エラーシェーダー検出");
             var result = rule.Validate(target);
             Assert.That(result.RuleName, Is.EqualTo("エラーシェーダー検出"));
-            Assert.That(result.Issues.Count, Is.EqualTo(2));
+            Assert.That(result.Issues.Count, Is.EqualTo(3));
             Assert.That(result.Issues[0].level, Is.EqualTo(IssueLevel.Error));
             Assert.That(result.Issues[0].target.name, Is.EqualTo("HiddenInternalErrorShaderObject"));
-            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("シェーダエラーが存在するオブジェクト({0})があります。", "HiddenInternalErrorShaderObject")));
+            Assert.That(result.Issues[0].message, Is.EqualTo(string.Format("オブジェクト({0})のマテリアルで正しいシェーダーが参照されていません。", "HiddenInternalErrorShaderObject")));
             Assert.That(result.Issues[0].solution, Is.Empty);
             Assert.That(result.Issues[0].solutionURL, Is.Empty);
             Assert.That(result.Issues[1].level, Is.EqualTo(IssueLevel.Error));
             Assert.That(result.Issues[1].target.name, Is.EqualTo("ErrorShaderObject"));
-            Assert.That(result.Issues[1].message, Is.EqualTo(string.Format("シェーダエラーが存在するオブジェクト({0})があります。", "ErrorShaderObject")));
+            Assert.That(result.Issues[1].message, Is.EqualTo(string.Format("オブジェクト({0})でシェーダーエラーが検出されました。", "ErrorShaderObject")));
             Assert.That(result.Issues[1].solution, Is.Empty);
             Assert.That(result.Issues[1].solutionURL, Is.Empty);
+            Assert.That(result.Issues[2].level, Is.EqualTo(IssueLevel.Error));
+            Assert.That(result.Issues[2].target.name, Is.EqualTo("NoneMaterialObject"));
+            Assert.That(result.Issues[2].message, Is.EqualTo(string.Format("オブジェクト({0})のRendererにマテリアルの参照がありません。", "NoneMaterialObject")));
+            Assert.That(result.Issues[2].solution, Is.Empty);
+            Assert.That(result.Issues[2].solutionURL, Is.Empty);
         }
     }
 }

--- a/VitDeck/Assets/VitDeck/Validator/Tests/B04_TestErrorShaderRule.cs.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/B04_TestErrorShaderRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4429aa77a810ae4b8355e8032ece5b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c10deae356eb575449879b0b007e9733
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/B04_ErrorShaderRule.unity
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/B04_ErrorShaderRule.unity
@@ -113,6 +113,90 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &253357245
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 253357249}
+  - component: {fileID: 253357248}
+  - component: {fileID: 253357247}
+  - component: {fileID: 253357246}
+  m_Layer: 0
+  m_Name: CorrectShaderObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &253357246
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 253357245}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!135 &253357247
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 253357245}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &253357248
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 253357245}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &253357249
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 253357245}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &529787897
 GameObject:
   m_ObjectHideFlags: 0
@@ -191,11 +275,95 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 529787897}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7.03, y: 0, z: 0}
-  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_LocalPosition: {x: 10, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1075678067
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1075678071}
+  - component: {fileID: 1075678070}
+  - component: {fileID: 1075678069}
+  - component: {fileID: 1075678068}
+  m_Layer: 0
+  m_Name: NoneMaterialObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1075678068
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1075678067}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!135 &1075678069
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1075678067}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1075678070
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1075678067}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1075678071
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1075678067}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -10, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1277450427
 GameObject:
@@ -275,8 +443,8 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1277450427}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -5.65, y: 0, z: 0}
-  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_LocalPosition: {x: 3, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/B04_ErrorShaderRule.unity
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/B04_ErrorShaderRule.unity
@@ -1,0 +1,429 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 8
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 9
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &529787897
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 529787901}
+  - component: {fileID: 529787900}
+  - component: {fileID: 529787899}
+  - component: {fileID: 529787898}
+  m_Layer: 0
+  m_Name: HiddenInternalErrorShaderObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &529787898
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 529787897}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 2de171b9b5b1fcb4dae3847f5ac9cde2, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!135 &529787899
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 529787897}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &529787900
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 529787897}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &529787901
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 529787897}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7.03, y: 0, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1277450427
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1277450431}
+  - component: {fileID: 1277450430}
+  - component: {fileID: 1277450429}
+  - component: {fileID: 1277450428}
+  m_Layer: 0
+  m_Name: ErrorShaderObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1277450428
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1277450427}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 4b51a43c4c2543c45becc3a479cddd8c, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!135 &1277450429
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1277450427}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1277450430
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1277450427}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1277450431
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1277450427}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.65, y: 0, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1312677463
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1312677467}
+  - component: {fileID: 1312677466}
+  - component: {fileID: 1312677465}
+  - component: {fileID: 1312677464}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1312677464
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1312677463}
+  m_Enabled: 1
+--- !u!124 &1312677465
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1312677463}
+  m_Enabled: 1
+--- !u!20 &1312677466
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1312677463}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1312677467
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1312677463}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2008730212
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2008730214}
+  - component: {fileID: 2008730213}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &2008730213
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2008730212}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &2008730214
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2008730212}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/B04_ErrorShaderRule.unity.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/B04_ErrorShaderRule.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dded8c5e20167ab4c8294c1327737e88
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/Error Shader Material.mat
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/Error Shader Material.mat
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Error Shader Material
+  m_Shader: {fileID: 4800000, guid: 42fc4c9d6a6b1ac4fb66e6f7b678da25, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/Error Shader Material.mat.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/Error Shader Material.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b51a43c4c2543c45becc3a479cddd8c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/ErrorShader.shader
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/ErrorShader.shader
@@ -1,0 +1,58 @@
+﻿Shader "Unlit/ErrorShader"
+{
+	Properties
+	{
+		_MainTex ("Texture", 2D) = "white" {}
+	}
+	SubShader
+	{
+		Tags { "RenderType"="Opaque" }
+		LOD 100
+
+		Pass
+		{
+			//CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			// make fog work
+			#pragma multi_compile_fog
+			
+			#include "UnityCG.cginc"
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			struct v2f
+			{
+				float2 uv : TEXCOORD0;
+				UNITY_FOG_COORDS(1)
+				float4 vertex : SV_POSITION;
+			};
+
+			sampler2D _MainTex;
+			float4 _MainTex_ST;
+			
+			v2f vert (appdata v)
+			{
+				v2f o;
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+				UNITY_TRANSFER_FOG(o,o.vertex);
+				return o;
+			}
+			
+			fixed4 frag (v2f i) : SV_Target
+			{
+				// sample the texture
+				fixed4 col = tex2D(_MainTex, i.uv);
+				// apply fog
+				UNITY_APPLY_FOG(i.fogCoord, col);
+				return col;
+			}
+			ENDCG
+		}
+	}
+}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/ErrorShader.shader.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/ErrorShader.shader.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 42fc4c9d6a6b1ac4fb66e6f7b678da25
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/Null Reference Material.mat
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/Null Reference Material.mat
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Null Reference Material
+  m_Shader: {fileID: 4800000, guid: bd23616a85b910749a90dbcf65691ed0, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/Null Reference Material.mat.meta
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B04_ErrorShaderRule/Null Reference Material.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2de171b9b5b1fcb4dae3847f5ac9cde2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#74 の実装

## 概要
シーン上のGameObjectからシェーダーエラーを検出します。

## 検出するシェーダーエラーの種類
1. マテリアルからシェーダーの参照が外れている場合 (Hidden/InternalErrorShader)
2. シェーダーにコンパイルエラーがある場合 (material.shader.name == string.Empty)
3. Rendererからマテリアル自体の参照が外れている場合 
    - この場合もシェーダーが見つからないので、シーン上ではピンク表示(シェーダーエラー)になる