### PR TITLE
Feature/#121

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B02_ComponentWhitelistRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B02_ComponentWhitelistRule.cs
@@ -27,7 +27,7 @@ namespace VitDeck.Validator
                 var components = obj.GetComponents<Component>();
                 foreach (var cmp in components)
                 {
-                    if (cmp.GetType() == typeof(Transform))
+                    if (cmp == null || cmp.GetType() == typeof(Transform))
                         continue;
                     var findFlg = false;
                     var message = "";

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B03_ComponentBlacklistRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B03_ComponentBlacklistRule.cs
@@ -26,7 +26,7 @@ namespace VitDeck.Validator
                 var components = obj.GetComponents<Component>();
                 foreach (var cmp in components)
                 {
-                    if (cmp.GetType() == typeof(Transform))
+                    if (cmp == null || cmp.GetType() == typeof(Transform))
                         continue;
                     var message = "";
                     foreach (var reference in references)

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B02_ComponentWhitelistRule/B02_ComponentWhitelistRule.unity
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B02_ComponentWhitelistRule/B02_ComponentWhitelistRule.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -113,6 +113,46 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &765597761
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 765597763}
+  - component: {fileID: 765597762}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &765597762
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 765597761}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ab67642e95526de479360557e2b28ba6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &765597763
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 765597761}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.29213047, y: 2.3126338, z: 0.44371632}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1181681521
 GameObject:
   m_ObjectHideFlags: 0

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B03_ComponentBlacklistRule/B03_ComponentBlacklistRule.unity
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B03_ComponentBlacklistRule/B03_ComponentBlacklistRule.unity
@@ -113,6 +113,46 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &535691064
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 535691066}
+  - component: {fileID: 535691065}
+  m_Layer: 0
+  m_Name: MissingScript
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &535691065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 535691064}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 063cc926b7199ed43ae6628af7104865, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &535691066
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 535691064}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.29213047, y: 2.3126338, z: 0.44371632}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &540229237
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Fix #121
`obj.GetComponents<Component>();`で取得したコンポーネント中にnullが含まれていた場合は無視するよう修正。
（別途Missingルールで検出される想定）