### PR TITLE
Feature/#132

### DIFF
--- a/release.bat
+++ b/release.bat
@@ -30,7 +30,9 @@ del /s /q "VitDeck\%VITDECK_ROOT%\Config\UserSettings.asset"
 
 echo Copy documents >> %BAT_LOG% 2>&1
 copy /Y LICENSE VitDeck\%VITDECK_ROOT%\LICENSE.txt >> %BAT_LOG% 2>&1
+copy /Y releaseAssets\LICENSE.txt.meta VitDeck\%VITDECK_ROOT%\LICENSE.txt.meta >> %BAT_LOG% 2>&1
 copy /Y README.md VitDeck\%VITDECK_ROOT%\README.txt >> %BAT_LOG% 2>&1
+copy /Y releaseAssets\README.txt.meta VitDeck\%VITDECK_ROOT%\README.txt.meta >> %BAT_LOG% 2>&1
 
 
 echo Mount >> %BAT_LOG% 2>&1

--- a/releaseAssets/LICENSE.txt.meta
+++ b/releaseAssets/LICENSE.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f96676051e7fb7645893f98d2f6adc4c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/releaseAssets/README.txt.meta
+++ b/releaseAssets/README.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ce9eb8d4dc599db45abf775e3bfb3f1a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#132 の実装。
今後は1.0.0-vketB_betaで生成されたREADMEとLICENSEの.metaファイルをリリースバッチ実行時にエクスポートするフォルダ内にコピー配置してGUIDが新規生成されることを防ぐ。

