### PR TITLE
Fix #118

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/MissingFinder.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/MissingFinder.cs
@@ -80,35 +80,7 @@ namespace VitDeck.Validator
             var material = unityObject as Material;
             if (material != null)
             {
-                if (material.shader != null)
-                {
-                    //設定中のシェーダーに存在するプロパティの取得
-                    var shaderProperties = new HashSet<string>();
-                    var count = ShaderUtil.GetPropertyCount(material.shader);
-                    for (int i = 0; i < count; i++)
-                    {
-                        string propName = ShaderUtil.GetPropertyName(material.shader, i);
-                        shaderProperties.Add(propName);
-                    }
-
-                    var matSo = new SerializedObject(material);
-                    var matSp = matSo.FindProperty("m_SavedProperties");
-                    var texEnvsSp = matSp.FindPropertyRelative("m_TexEnvs");
-                    for (int i = 0; i < texEnvsSp.arraySize; i++)
-                    {
-                        var prop = texEnvsSp.GetArrayElementAtIndex(i);
-                        var propName = prop.FindPropertyRelative("first").stringValue;
-                        //設定中のシェーダーに存在するテクスチャ指定プロパティのみmissing検証
-                        if (shaderProperties.Contains(propName))
-                        {
-                            var tex = prop.FindPropertyRelative("second.m_Texture");
-                            if (tex != null && IsMissing(tex))
-                            {
-                                missingProperties.Add(tex);
-                            }
-                        }
-                    }
-                }
+                CheckMaterial(material);
                 return;
             }
 
@@ -127,6 +99,39 @@ namespace VitDeck.Validator
                 else if (HasValidObjectReference(current))
                 {
                     FindRecursive(current.objectReferenceValue);
+                }
+            }
+        }
+
+        private void CheckMaterial(Material material)
+        {
+            if (material.shader != null)
+            {
+                //設定中のシェーダーに存在するプロパティの取得
+                var shaderProperties = new HashSet<string>();
+                var count = ShaderUtil.GetPropertyCount(material.shader);
+                for (int i = 0; i < count; i++)
+                {
+                    string propName = ShaderUtil.GetPropertyName(material.shader, i);
+                    shaderProperties.Add(propName);
+                }
+
+                var matSo = new SerializedObject(material);
+                var matSp = matSo.FindProperty("m_SavedProperties");
+                var texEnvsSp = matSp.FindPropertyRelative("m_TexEnvs");
+                for (int i = 0; i < texEnvsSp.arraySize; i++)
+                {
+                    var prop = texEnvsSp.GetArrayElementAtIndex(i);
+                    var propName = prop.FindPropertyRelative("first").stringValue;
+                    //設定中のシェーダーに存在するテクスチャ指定プロパティのみmissing検証
+                    if (shaderProperties.Contains(propName))
+                    {
+                        var tex = prop.FindPropertyRelative("second.m_Texture");
+                        if (tex != null && IsMissing(tex))
+                        {
+                            missingProperties.Add(tex);
+                        }
+                    }
                 }
             }
         }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/MissingFinder.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/MissingFinder.cs
@@ -129,7 +129,7 @@ namespace VitDeck.Validator
                         var tex = prop.FindPropertyRelative("second.m_Texture");
                         if (tex != null && IsMissing(tex))
                         {
-                            missingProperties.Add(tex);
+                            missingProperties.Add(prop);
                         }
                     }
                 }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/MissingFinder.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/MissingFinder.cs
@@ -76,6 +76,42 @@ namespace VitDeck.Validator
                 return;
             }
 
+            // Materialの場合の対応。
+            var material = unityObject as Material;
+            if (material != null)
+            {
+                if (material.shader != null)
+                {
+                    //設定中のシェーダーに存在するプロパティの取得
+                    var shaderProperties = new HashSet<string>();
+                    var count = ShaderUtil.GetPropertyCount(material.shader);
+                    for (int i = 0; i < count; i++)
+                    {
+                        string propName = ShaderUtil.GetPropertyName(material.shader, i);
+                        shaderProperties.Add(propName);
+                    }
+
+                    var matSo = new SerializedObject(material);
+                    var matSp = matSo.FindProperty("m_SavedProperties");
+                    var texEnvsSp = matSp.FindPropertyRelative("m_TexEnvs");
+                    for (int i = 0; i < texEnvsSp.arraySize; i++)
+                    {
+                        var prop = texEnvsSp.GetArrayElementAtIndex(i);
+                        var propName = prop.FindPropertyRelative("first").stringValue;
+                        //設定中のシェーダーに存在するテクスチャ指定プロパティのみmissing検証
+                        if (shaderProperties.Contains(propName))
+                        {
+                            var tex = prop.FindPropertyRelative("second.m_Texture");
+                            if (tex != null && IsMissing(tex))
+                            {
+                                missingProperties.Add(tex);
+                            }
+                        }
+                    }
+                }
+                return;
+            }
+
             // その他のObjectの場合の対応。
             var serializedObject = new SerializedObject(unityObject);
             var iterator = serializedObject.GetIterator();
@@ -104,7 +140,7 @@ namespace VitDeck.Validator
         private static bool IsMissing(SerializedProperty serializedProperty)
         {
             if (serializedProperty.propertyType != SerializedPropertyType.ObjectReference ||
-                serializedProperty.objectReferenceValue != null )
+                serializedProperty.objectReferenceValue != null)
             {
                 return false;
             }

--- a/VitDeck/Assets/VitDeck/Validator/Tests/B06_TestMissingReferenceRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/B06_TestMissingReferenceRule.cs
@@ -64,7 +64,7 @@ namespace VitDeck.Validator.Test
                 issue.target == GameObject.Find("MissingScriptObject")));
 
             Assert.NotNull(result.Issues.Find(issue =>
-                issue.message == "missingフィールドが含まれています！（B06_MissingTestMaterial > Texture）" &&
+                issue.message == "missingフィールドが含まれています！（B06_MissingTestMaterial > _MainTex）" &&
                 issue.target == AssetDatabase.LoadMainAssetAtPath(testData + "/B06_MissingTestMaterial.mat")));
 
             Assert.NotNull(result.Issues.Find(issue =>

--- a/VitDeck/Assets/VitDeck/Validator/Tests/Data/B06_MissingReferenceRule/B06_MissingTestMaterial.mat
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/Data/B06_MissingReferenceRule/B06_MissingTestMaterial.mat
@@ -54,6 +54,10 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _Missing:
+        m_Texture: {fileID: 2800000, guid: 18fd8d9e8a4651649a45add35a290000, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     m_Floats:
     - _BumpScale: 1
     - _Cutoff: 0.5


### PR DESCRIPTION
Fix #118
Add logic for finding missing material
判定対象がMaterialだった場合にシェーダーに設定しているフィールドのみ検証するようロジックを追加しました。

SerializedObjectの扱い方についておかしなところが無いかの観点でレビューしていただけると助かります。
