### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 VketTools
+Copyright (c) 2019 VitDeck
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fix tool name
Fix #143 
ライセンスの著作権者をツール名のVitDeckにあわせました。