### PR TITLE
feature/#32

### DIFF
--- a/VitDeck/Assets/VitDeck/TemplateLoader/GUI/TemplateLoaderGUI.cs
+++ b/VitDeck/Assets/VitDeck/TemplateLoader/GUI/TemplateLoaderGUI.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VitDeck.Utilities;
@@ -26,6 +27,16 @@ namespace VitDeck.TemplateLoader.GUI
             window = GetWindow<TemplateLoaderWindow>(false, "VitDeck");
             Init();
             window.Show();
+        }
+
+        [UnityEditor.Callbacks.DidReloadScripts]
+        static void DidReloadScripts()
+        {
+            window = Resources.FindObjectsOfTypeAll<TemplateLoaderWindow>().FirstOrDefault();
+            if (window != null)
+            {
+                Init();
+            }
         }
 
         static void Init()


### PR DESCRIPTION
#32 の修正です。
再コンパイル時に最低限リストが消えないようになりました。

ただし、以下の情報は失われます。
- 選択中の項目
- ライセンス条文のスクロール位置
- 置き換え文字列に入力した内容