### PR TITLE
Feature/#150

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ VitDeck/Assets/VitDeck/Templates/*
 !Sample_template
 VitDeck/Assets/VitDeck/Config/UserSettings.asset
 VitDeck/Assets/VitDeck/Config/UserSettings.asset.meta
+
+#Template loader temporary folder
+VitDeck/Assets/VitDeck/Temporary*

--- a/VitDeck/Assets/VitDeck.meta
+++ b/VitDeck/Assets/VitDeck.meta
@@ -1,5 +1,7 @@
 fileFormatVersion: 2
 guid: 0b9cd90d6c2ac9545a9c918d21b032fa
+labels:
+- VitDeck.RootFolder
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/VitDeck/Assets/VitDeck/TemplateLoader/TemplateLoader.cs
+++ b/VitDeck/Assets/VitDeck/TemplateLoader/TemplateLoader.cs
@@ -28,7 +28,7 @@ namespace VitDeck.TemplateLoader
         public static bool Load(string templateFolderName, Dictionary<string, string> replaceLsit, string copyDistinationPath = "Assets")
         {
             const string templateAssetsFolder = "TemplateAssets";
-            const string temporaryFolderPath = "Assets/VitDeck/Temporary";
+            string temporaryFolderPath = AssetUtility.RootFolderPath + Path.AltDirectorySeparatorChar + "Temporary";
             var separatorChar = Path.AltDirectorySeparatorChar;
             var templateFolderPath = GetTemplatesFolderPath() + separatorChar + templateFolderName;
             var copyRootPath = templateFolderPath + separatorChar + templateAssetsFolder;
@@ -59,7 +59,7 @@ namespace VitDeck.TemplateLoader
             //Create temporary folder
             if (AssetDatabase.IsValidFolder(temporaryFolderPath))
                 AssetDatabase.DeleteAsset(temporaryFolderPath);
-            AssetDatabase.CreateFolder("Assets/VitDeck", "Temporary");
+            AssetDatabase.CreateFolder(AssetUtility.RootFolderPath, "Temporary");
 
             //Check distination path
             if (CheckDestinationExists(assetDictionary, copyRootPath) ||

--- a/VitDeck/Assets/VitDeck/Utilities/AssetUtility.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/AssetUtility.cs
@@ -12,6 +12,7 @@ namespace VitDeck.Utilities
     {
         private static string _imageFolderPath;
         private static string _configFolderPath;
+        private static string _rootFolderPath;
         /// <summary>
         /// VitDeck用画像フォルダのパス
         /// </summary>
@@ -46,6 +47,25 @@ namespace VitDeck.Utilities
                     _configFolderPath = GetFolderPath("VitDeck.ConfigFolder");
                 }
                 return _configFolderPath;
+            }
+        }
+
+        /// <summary>
+        /// VitDeckルートフォルダのパス
+        /// </summary>
+        /// <remarks>
+        /// Unityでラベルが付与されているアセットの一つ目のパスを返す。
+        /// 存在しない場合はDirectoryNotFoundExceptionを返す。
+        /// </remarks>
+        public static string RootFolderPath
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_rootFolderPath))
+                {
+                    _rootFolderPath = GetFolderPath("VitDeck.RootFolder");
+                }
+                return _rootFolderPath;
             }
         }
 

--- a/VitDeck/Assets/VitDeck/Utilities/Tests/AssetUtilityTest.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/Tests/AssetUtilityTest.cs
@@ -14,5 +14,10 @@ namespace VitDeck.Utilities.Tests
         {
             Assert.That(AssetUtility.ConfigFolderPath, Is.EqualTo("Assets/VitDeck/Config"));
         }
+        [Test]
+        public void TestRootFolderPath()
+        {
+            Assert.That(AssetUtility.RootFolderPath, Is.EqualTo("Assets/VitDeck"));
+        }
     }
 }


### PR DESCRIPTION
#150 の修正です。
テンプレートロード時に何らかのエラーにより中断した場合に、コピーされたアセットが中途半端に残ってしまう場合があったため以下の手順に変更しました。

## 変更前
1. ロード先のパス（e.g. `Assets`）にアセットを複製
2. アセットのリネームや参照の修正を実行する

## 変更後
1. `VitDeck/Temporary`フォルダを作成しその中にアセットを複製
  （すでに`Temporary`フォルダが存在している場合は中身ごと一度削除して空フォルダを再作成）
2. アセットのリネームや参照の修正を実行する
3. `Temporary`フォルダ直下のアセットをロード先パス（e.g. `Assets`）にMoveAssetで移動する。

こちらの実現にあたってAssetUtilityにRootFolderPathを追加しVitDeckのルートフォルダ（`Assets/VitDeck`)を取得できるようにしています。

@sokuhatiku 
処理手順で他に問題がでる可能性ないかの観点でレビューをお願いできますか？