### PR TITLE
Feature/updater

### DIFF
--- a/VitDeck/Assets/VitDeck/Main/GUI/InfoWindow.cs
+++ b/VitDeck/Assets/VitDeck/Main/GUI/InfoWindow.cs
@@ -38,17 +38,19 @@ namespace VitDeck.Main.GUI
         private void Init()
         {
             versionLabel = "Version : " + VersionUtility.GetVersion();
-
-            JsonReleaseInfo.FetchInfo(releaseURL);
-            if (JsonReleaseInfo.GetVersion() == null)
+            if (UpdateCheck.Enabled)
             {
-                version = "None";
+                JsonReleaseInfo.FetchInfo(releaseURL);
+                if (JsonReleaseInfo.GetVersion() == null)
+                {
+                    version = "None";
+                }
+                else
+                {
+                    version = JsonReleaseInfo.GetVersion();
+                }
+                latestVersionLabel = "Latest Version : " + version;
             }
-            else
-            {
-                version = JsonReleaseInfo.GetVersion();
-            }
-            latestVersionLabel = "Latest Version : " + version;
         }
 
         private void OnEnable()
@@ -58,9 +60,15 @@ namespace VitDeck.Main.GUI
 
         private void OnGUI()
         {
+            //Version
             EditorGUILayout.LabelField(versionLabel);
-            EditorGUILayout.LabelField(latestVersionLabel);
-            VersionCheckLabelField();
+            //Updater
+            if (UpdateCheck.Enabled)
+            {
+                EditorGUILayout.LabelField(latestVersionLabel);
+                VersionCheckLabelField();
+            }
+            //Developer info
             CustomGUILayout.URLButton("VitDeck on GitHub", "https://github.com/vkettools/VitDeck", buttonStyle);
         }
 

--- a/VitDeck/Assets/VitDeck/Main/GUI/InfoWindow.cs
+++ b/VitDeck/Assets/VitDeck/Main/GUI/InfoWindow.cs
@@ -15,9 +15,7 @@ namespace VitDeck.Main.GUI
         [SerializeField]
         string latestVersionLabel = null;
         [SerializeField]
-        string version = null;
-
-        private static readonly string releaseURL = JsonReleaseInfo.GetReleaseUrl();
+        string latestVersion = null;
 
         private GUILayoutOption[] buttonStyle = new GUILayoutOption[] { GUILayout.Width(130) };
 
@@ -40,16 +38,16 @@ namespace VitDeck.Main.GUI
             versionLabel = "Version : " + VersionUtility.GetVersion();
             if (UpdateCheck.Enabled)
             {
-                JsonReleaseInfo.FetchInfo(releaseURL);
-                if (JsonReleaseInfo.GetVersion() == null)
+                var version = UpdateCheck.GetLatestVersion();
+                if (version == null)
                 {
-                    version = "None";
+                    latestVersion = "None";
                 }
                 else
                 {
-                    version = JsonReleaseInfo.GetVersion();
+                    latestVersion = version;
                 }
-                latestVersionLabel = "Latest Version : " + version;
+                latestVersionLabel = "Latest Version : " + latestVersion;
             }
         }
 
@@ -74,12 +72,12 @@ namespace VitDeck.Main.GUI
 
         private void VersionCheckLabelField()
         {
-            if (version == "None")
+            if (latestVersion == "None")
             {
                 EditorGUILayout.LabelField("現在、最新のバージョンを取得できません。");
                 EditorGUILayout.LabelField("ネットワーク接続を確認し、しばらく待ってやり直してください。");
             }
-            else if (UpdateCheck.IsLatest(releaseURL))
+            else if (UpdateCheck.IsLatest())
             {
                 EditorGUILayout.LabelField("最新のバージョンです");
             }
@@ -87,7 +85,7 @@ namespace VitDeck.Main.GUI
             {
                 EditorGUILayout.LabelField("最新のバージョンにアップデートしてください");
                 if (GUILayout.Button("Update"))
-                    UpdateCheck.UpdatePackage(version);
+                    UpdateCheck.UpdatePackage(latestVersion);
             }
         }
     }

--- a/VitDeck/Assets/VitDeck/Main/GUI/InfoWindow.cs
+++ b/VitDeck/Assets/VitDeck/Main/GUI/InfoWindow.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEditor;
 using UnityEngine;
 using VitDeck.Utilities;
@@ -23,9 +24,18 @@ namespace VitDeck.Main.GUI
         public static void ShowWindow()
         {
             GetWindow<InfoWindow>(true, "VitDeck");
+            AssetDatabase.importPackageCompleted -= ImportCallback;
+            AssetDatabase.importPackageCompleted += ImportCallback;
         }
 
-        private void OnEnable()
+        private static void ImportCallback(string packageName)
+        {
+            var window = GetWindow<InfoWindow>(true, "VitDeck");
+            if (window != null)
+                window.Init();
+        }
+
+        private void Init()
         {
             versionLabel = "Version : " + VersionUtility.GetVersion();
 
@@ -39,6 +49,11 @@ namespace VitDeck.Main.GUI
                 version = JsonReleaseInfo.GetVersion();
             }
             latestVersionLabel = "Latest Version : " + version;
+        }
+
+        private void OnEnable()
+        {
+            Init();
         }
 
         private void OnGUI()

--- a/VitDeck/Assets/VitDeck/Main/JsonReleaseInfo.cs
+++ b/VitDeck/Assets/VitDeck/Main/JsonReleaseInfo.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System;
 using System.Collections;
 using VitDeck.Utilities;
@@ -11,7 +11,7 @@ namespace VitDeck.Main
     /// <summary>
     public static class JsonReleaseInfo
     {
-        private static string releaseUrl = "https://vkettools.github.io/VitDeckTest/releases/latest.json";
+        private static string releaseUrl = "";
         private static string version = null;
         private static string packageName = null;
         private static string downloadUrl = null;

--- a/VitDeck/Assets/VitDeck/Main/JsonReleaseInfo.cs
+++ b/VitDeck/Assets/VitDeck/Main/JsonReleaseInfo.cs
@@ -38,13 +38,17 @@ namespace VitDeck.Main
 
         public static void FetchInfo(string releaseUrl)
         {
+            if (string.IsNullOrEmpty(releaseUrl))
+                return;
             var release = ReleaseEnumerator(releaseUrl);
             while (release.MoveNext()) { }
-            var info = JsonUtility.FromJson<ReleaseInfo>(release.Current.ToString());
-
-            version = info.version;
-            packageName = info.package_name;
-            downloadUrl = info.download_url;
+            if (release != null && release.Current != null)
+            {
+                var info = JsonUtility.FromJson<ReleaseInfo>(release.Current.ToString());
+                version = info.version;
+                packageName = info.package_name;
+                downloadUrl = info.download_url;
+            }
         }
 
         static IEnumerator ReleaseEnumerator(string releaseUrl)

--- a/VitDeck/Assets/VitDeck/Main/Tests/UpdateCheckTest.cs
+++ b/VitDeck/Assets/VitDeck/Main/Tests/UpdateCheckTest.cs
@@ -6,7 +6,7 @@ namespace VitDeck.Main.Tests
     public class UpdateCheckTest
     {
         private static readonly string testURL = "https://vkettools.github.io/VitDeckTest/releases/latest.json";
-        
+
         [Test]
         public void TestLatestVersioning()
         {
@@ -14,6 +14,13 @@ namespace VitDeck.Main.Tests
             string version = JsonReleaseInfo.GetVersion();
             Assert.That(VersionUtility.IsSemanticVersioning(version), Is.True);
             Assert.That(version, Is.EqualTo("1.0.0"));
+        }
+        [Test]
+        public void TestGetLatestVersion()
+        {
+            var version = UpdateCheck.GetLatestVersion();
+            if(version != null)
+                Assert.That(version, Is.Not.Empty);
         }
     }
 }

--- a/VitDeck/Assets/VitDeck/Main/UpdateCheck.cs
+++ b/VitDeck/Assets/VitDeck/Main/UpdateCheck.cs
@@ -18,6 +18,12 @@ namespace VitDeck.Main
             }
         }
 
+        public static string GetLatestVersion()
+        {
+            JsonReleaseInfo.FetchInfo(JsonReleaseInfo.GetReleaseUrl());
+            return JsonReleaseInfo.GetVersion();
+        }
+
         public static void UpdatePackage(string tag)
         {
             string downloadUrl = JsonReleaseInfo.GetDownloadURL();
@@ -29,7 +35,7 @@ namespace VitDeck.Main
             downloader.Settlement(packageName);
         }
 
-        public static bool IsLatest(string releaseUrl)
+        public static bool IsLatest()
         {
             string localVersion = VersionUtility.GetVersion();
             string latestVersion = JsonReleaseInfo.GetVersion();

--- a/VitDeck/Assets/VitDeck/Main/UpdateCheck.cs
+++ b/VitDeck/Assets/VitDeck/Main/UpdateCheck.cs
@@ -10,6 +10,14 @@ namespace VitDeck.Main
     /// </summary>
     public static class UpdateCheck
     {
+        public static bool Enabled
+        {
+            get
+            {
+                return !string.IsNullOrEmpty(JsonReleaseInfo.GetReleaseUrl());
+            }
+        }
+
         public static void UpdatePackage(string tag)
         {
             string downloadUrl = JsonReleaseInfo.GetDownloadURL();


### PR DESCRIPTION
アップデート機能関連の修正です。
各コミットごとに以下の変更を行いました。

- #161 
パッケージのインポートが完了したタイミングでInfoWindowsの初期化を行うようにしました。

- #107 
UpdateCheckにEnabledプロパティを追加して無効な場合はアップデート関連処理と表示をしないようにしました。
Enabledはリリース情報URLが設定されている場合にtrueになります。
合わせてデフォルトのURLは設定しないようにしました。
![image](https://user-images.githubusercontent.com/46106857/63633347-43f9c000-c682-11e9-8472-6af82416cf72.png)

- #162
Httpエラーが発生した場合のnull判定処理が漏れていたのを追加しました。
無効なURLを設定していた場合は以下の表記になります。
![image](https://user-images.githubusercontent.com/46106857/63633342-0dbc4080-c682-11e9-82c0-62ba19224c30.png)

またInfoWindow.cs内でJsonReleaseInfoのロジックを実行している部分をUpdateCheckに移動してUIとロジックを分離するリファクタリングを行いました。