### PR TITLE
Feature/#64

### DIFF
--- a/VitDeck/Assets/VitDeck/Config/ProductInfo.asset
+++ b/VitDeck/Assets/VitDeck/Config/ProductInfo.asset
@@ -12,3 +12,5 @@ MonoBehaviour:
   m_Name: ProductInfo
   m_EditorClassIdentifier: 
   version: 1.0.0-dev
+  developerLinkTitle: VitDeck on GitHub
+  developerLinkURL: https://github.com/vkettools/VitDeck

--- a/VitDeck/Assets/VitDeck/Main/GUI/InfoWindow.cs
+++ b/VitDeck/Assets/VitDeck/Main/GUI/InfoWindow.cs
@@ -17,7 +17,8 @@ namespace VitDeck.Main.GUI
         [SerializeField]
         string latestVersion = null;
 
-        private static ProductInfo productInfo = null;
+        private static string developerLinkTitle = null;
+        private static string developerLinkURL = null;
         private GUILayoutOption[] buttonStyle = new GUILayoutOption[] { GUILayout.Width(130) };
 
         public static void ShowWindow()
@@ -37,7 +38,8 @@ namespace VitDeck.Main.GUI
         private void Init()
         {
             versionLabel = "Version : " + VersionUtility.GetVersion();
-            productInfo = ProductInfoUtility.GetProductInfo();
+            developerLinkTitle = ProductInfoUtility.GetDeveloperLinkTitle();
+            developerLinkURL = ProductInfoUtility.GetDeveloperLinkURL();
             if (UpdateCheck.Enabled)
             {
                 var version = UpdateCheck.GetLatestVersion();
@@ -69,11 +71,10 @@ namespace VitDeck.Main.GUI
                 VersionCheckLabelField();
             }
             //Developer info
-            if (productInfo != null &&
-                !string.IsNullOrEmpty(productInfo.developerLinkTitle) &&
-                !string.IsNullOrEmpty(productInfo.developerLinkURL))
+            if (!string.IsNullOrEmpty(developerLinkTitle) &&
+                !string.IsNullOrEmpty(developerLinkURL))
             {
-                CustomGUILayout.URLButton(productInfo.developerLinkTitle, productInfo.developerLinkURL, buttonStyle);
+                CustomGUILayout.URLButton(developerLinkTitle, developerLinkURL, buttonStyle);
             }
         }
 

--- a/VitDeck/Assets/VitDeck/Main/GUI/InfoWindow.cs
+++ b/VitDeck/Assets/VitDeck/Main/GUI/InfoWindow.cs
@@ -17,6 +17,7 @@ namespace VitDeck.Main.GUI
         [SerializeField]
         string latestVersion = null;
 
+        private static ProductInfo productInfo = null;
         private GUILayoutOption[] buttonStyle = new GUILayoutOption[] { GUILayout.Width(130) };
 
         public static void ShowWindow()
@@ -36,6 +37,7 @@ namespace VitDeck.Main.GUI
         private void Init()
         {
             versionLabel = "Version : " + VersionUtility.GetVersion();
+            productInfo = ProductInfoUtility.GetProductInfo();
             if (UpdateCheck.Enabled)
             {
                 var version = UpdateCheck.GetLatestVersion();
@@ -67,7 +69,12 @@ namespace VitDeck.Main.GUI
                 VersionCheckLabelField();
             }
             //Developer info
-            CustomGUILayout.URLButton("VitDeck on GitHub", "https://github.com/vkettools/VitDeck", buttonStyle);
+            if (productInfo != null &&
+                !string.IsNullOrEmpty(productInfo.developerLinkTitle) &&
+                !string.IsNullOrEmpty(productInfo.developerLinkURL))
+            {
+                CustomGUILayout.URLButton(productInfo.developerLinkTitle, productInfo.developerLinkURL, buttonStyle);
+            }
         }
 
         private void VersionCheckLabelField()

--- a/VitDeck/Assets/VitDeck/Utilities/ProductInfo.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/ProductInfo.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 
 namespace VitDeck.Utilities
@@ -7,5 +6,9 @@ namespace VitDeck.Utilities
     {
         [SerializeField]
         public string version = "";
+        [SerializeField]
+        public string developerLinkTitle = "VitDeck on GitHub";
+        [SerializeField]
+        public string developerLinkURL = "https://github.com/vkettools/VitDeck";
     }
 }

--- a/VitDeck/Assets/VitDeck/Utilities/ProductInfoUtility.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/ProductInfoUtility.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace VitDeck.Utilities
+{
+    /// <summary>
+    /// 製品情報を提供する
+    /// </summary>
+    public static class ProductInfoUtility
+    {
+        private const string fileName = "ProductInfo.asset";
+        /// <summary>
+        /// 製品情報を取得する
+        /// </summary>
+        /// <returns>製品情報</returns>
+        public static ProductInfo GetProductInfo()
+        {
+            var assetPath = Path.Combine(AssetUtility.ConfigFolderPath, fileName);
+            var productInfo = AssetDatabase.LoadAssetAtPath<ProductInfo>(assetPath);
+            if (productInfo == null)
+                Debug.LogError("Failed to load ProductInfo.");
+            return productInfo;
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Utilities/ProductInfoUtility.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/ProductInfoUtility.cs
@@ -14,13 +14,39 @@ namespace VitDeck.Utilities
         /// 製品情報を取得する
         /// </summary>
         /// <returns>製品情報</returns>
-        public static ProductInfo GetProductInfo()
+        private static ProductInfo GetProductInfo()
         {
             var assetPath = Path.Combine(AssetUtility.ConfigFolderPath, fileName);
             var productInfo = AssetDatabase.LoadAssetAtPath<ProductInfo>(assetPath);
             if (productInfo == null)
                 Debug.LogError("Failed to load ProductInfo.");
             return productInfo;
+        }
+
+        /// <summary>
+        /// 開発者リンクのタイトル文字列を取得する
+        /// </summary>
+        /// <returns>開発者リンクのタイトル文字列</returns>
+        public static string GetDeveloperLinkTitle()
+        {
+            var title = "";
+            var productInfo = GetProductInfo();
+            if (productInfo != null)
+                title = productInfo.developerLinkTitle;
+            return title;
+        }
+
+        /// <summary>
+        /// 開発者リンクのURL文字列を取得する
+        /// </summary>
+        /// <returns>開発者リンクのURL文字列</returns>
+        public static string GetDeveloperLinkURL()
+        {
+            var url = "";
+            var productInfo = GetProductInfo();
+            if (productInfo != null)
+                url = productInfo.developerLinkURL;
+            return url;
         }
     }
 }

--- a/VitDeck/Assets/VitDeck/Utilities/ProductInfoUtility.cs.meta
+++ b/VitDeck/Assets/VitDeck/Utilities/ProductInfoUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09871b0cfb14d49458f96dcf00e77cc5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VitDeck/Assets/VitDeck/Utilities/Tests/ProductInfoUtilityTest.cs
+++ b/VitDeck/Assets/VitDeck/Utilities/Tests/ProductInfoUtilityTest.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+
+namespace VitDeck.Utilities.Tests
+{
+    public class ProductInfoUtilityTest
+    {
+        [Test]
+        public void TestGetDeveloperLinkTitle()
+        {
+            var title = ProductInfoUtility.GetDeveloperLinkTitle();
+            Assert.That(title, Is.EqualTo("VitDeck on GitHub"));
+        }
+        [Test]
+        public void TestGetDeveloperLinkURL()
+        {
+            var url = ProductInfoUtility.GetDeveloperLinkURL();
+            Assert.That(url, Is.EqualTo("https://github.com/vkettools/VitDeck"));
+        }
+    }
+}

--- a/VitDeck/Assets/VitDeck/Utilities/Tests/ProductInfoUtilityTest.cs.meta
+++ b/VitDeck/Assets/VitDeck/Utilities/Tests/ProductInfoUtilityTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62a63686928cfc54e9c05e9d5b8ee21f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#64 の改善です。
ProductInfoに以下の２点を追加しました。
- DeveloperLinkTitle
- DeveloperLinkURL

ProductInfoUtilityを新設して、InfoWindowの開発者リンクボタン情報はこれを経由し取得するよう変更しました。

ProductInfoは実行時に外部からの変更はさせたくないので直接オブジェクトを取得させず、ユーティリティクラスの各設定値用のメソッドで取得する方針にしています。

ProductInfoが存在しない場合は以下のエラーを表示します。
![image](https://user-images.githubusercontent.com/46106857/63650223-59a2de80-c783-11e9-9874-774f04d40614.png)
（こちらは手動テスト済みです）