### PR TITLE
Feature/booth bounds rule

### DIFF
--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B01_BoothBoundsRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B01_BoothBoundsRule.cs
@@ -115,6 +115,17 @@ namespace VitDeck.Validator
 
             public static BoundsData FromRenderer(Renderer renderer)
             {
+                //Recalculate bounds for ParticleSystem
+                var particleSystem = renderer.gameObject.GetComponent<ParticleSystem>();
+                if (particleSystem != null)
+                    particleSystem.Simulate(0f);
+                //Reculculate bounds for TrailRenderer
+                if (renderer is TrailRenderer)
+                {
+                    var originalFlag = renderer.enabled;
+                    renderer.enabled = !originalFlag;
+                    renderer.enabled = originalFlag;
+                }
                 return new BoundsData(renderer, renderer.bounds);
             }
         }

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B01_BoothBoundsRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B01_BoothBoundsRule.cs
@@ -40,7 +40,6 @@ namespace VitDeck.Validator
         {
             var oversizes = target
                 .GetAllObjects()
-                .Where(gameObject => gameObject.activeSelf && gameObject.activeInHierarchy)
                 .SelectMany(GetObjectBounds)
                 .Where(data => !LimitContains(data.bounds));
 

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B01_BoothBoundsRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B01_BoothBoundsRule.cs
@@ -35,8 +35,19 @@ namespace VitDeck.Validator
             var limit = new Bounds(center, size);
             limit.Expand(margin);
             this.limit = limit;
-            //marginの小数点以下の桁数+1桁の表示精度を指定
-            accuracy = string.Format("f{0}", (margin % 1).ToString().Length - "0.".Length + 1);
+            //size, marginのうち最小の桁数が指定されたものの小数点以下の桁数+1桁の表示精度を指定
+            var settingValues = new float[] { size.x, size.y, size.z, margin };
+            var DigitsCount = settingValues.Select(val => GetDigitCountUnderPoint(val)).Max<int>();
+            accuracy = string.Format("f{0}", DigitsCount + 1);
+        }
+
+        private int GetDigitCountUnderPoint(float val)
+        {
+            var pointIndex = val.ToString().IndexOf(".");
+            if (pointIndex == -1)
+                return 0;
+            else
+                return val.ToString().Substring(pointIndex).Length - 1;
         }
 
         protected override void Logic(ValidationTarget target)

--- a/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B01_BoothBoundsRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Rules/Booth/B01_BoothBoundsRule.cs
@@ -11,6 +11,7 @@ namespace VitDeck.Validator
     public class BoothBoundsRule : BaseRule
     {
         private readonly Bounds limit;
+        private readonly string accuracy;
 
         /// <summary>
         /// コンストラクタ。
@@ -34,6 +35,8 @@ namespace VitDeck.Validator
             var limit = new Bounds(center, size);
             limit.Expand(margin);
             this.limit = limit;
+            //marginの小数点以下の桁数+1桁の表示精度を指定
+            accuracy = string.Format("f{0}", (margin % 1).ToString().Length - "0.".Length + 1);
         }
 
         protected override void Logic(ValidationTarget target)
@@ -46,7 +49,7 @@ namespace VitDeck.Validator
             foreach (var oversize in oversizes)
             {
                 var limitSize = limit.size.ToString();
-                var message = string.Format("オブジェクトがブースサイズ制限{0}の外に出ています。{4}制限={1}{4}対象={2}{4}オブジェクトの種類={3}", limitSize, limit, oversize.bounds, oversize.objectReference.GetType().Name, System.Environment.NewLine);
+                var message = string.Format("オブジェクトがブースサイズ制限{0}の外に出ています。{4}制限={1}{4}対象={2}{4}オブジェクトの種類={3}", limitSize, limit.ToString(accuracy), oversize.bounds.ToString(accuracy), oversize.objectReference.GetType().Name, System.Environment.NewLine);
                 AddIssue(new Issue(oversize.objectReference, IssueLevel.Error, message));
             }
         }

--- a/VitDeck/Assets/VitDeck/Validator/Tests/B01_TestBoothBoundsRule.cs
+++ b/VitDeck/Assets/VitDeck/Validator/Tests/B01_TestBoothBoundsRule.cs
@@ -20,7 +20,7 @@ namespace VitDeck.Validator.Test
                 CreateRendererGameObject("TestTargetObject3", true, new Vector3(0, 1, 0), new Vector3(2, 2, 2)),
                 CreateRendererGameObject("TestTargetObject4", false, new Vector3(0, 100, 0), new Vector3(200, 200, 200)),
                 CreateRectGameObject("TestTargetObject5", true, new Vector3(0, 1, 0), new Vector2(2, 2) ),
-                CreateRectGameObject("TestTargetObject6", false, new Vector3(0, 1, 0), new Vector2(2, 2) ),
+                CreateRectGameObject("TestTargetObject6", false, new Vector3(1000, 1, 0), new Vector2(2, 2) ),
             };
 
             targetContainer = new ValidationTarget("Assets/VitDeck/Validator/Tests", allObjects: targetObjects);
@@ -28,10 +28,10 @@ namespace VitDeck.Validator.Test
 
         public static readonly object[] TestCases =
         {
-            CreateTestCase( "TestRule0", Vector3.zero, new Vector3(3, 5, 4), 0f, FailedTargetObjectIndices(null) ),
-            CreateTestCase( "TestRule1", Vector3.zero, new Vector3(2, 5, 4), 0f, FailedTargetObjectIndices(null) ),
-            CreateTestCase( "TestRule2", Vector3.zero, new Vector3(1.9f, 5, 4), 0f, FailedTargetObjectIndices(1, 3, 5) ),
-            CreateTestCase( "TestRule3", Vector3.zero, new Vector3(1.9f, 5, 4), 0.1f, FailedTargetObjectIndices(null) ),
+            CreateTestCase( "TestRule0", Vector3.zero, new Vector3(3, 5, 4), 0f, FailedTargetObjectIndices(2, 4, 6) ),
+            CreateTestCase( "TestRule1", Vector3.zero, new Vector3(2, 5, 4), 0f, FailedTargetObjectIndices(2, 4, 6) ),
+            CreateTestCase( "TestRule2", Vector3.zero, new Vector3(1.9f, 5, 4), 0f, FailedTargetObjectIndices(1, 3, 5, 6) ),
+            CreateTestCase( "TestRule3", Vector3.zero, new Vector3(1.9f, 5, 4), 0.1f, FailedTargetObjectIndices(2, 4, 6) ),
         };
 
         [TestCaseSource("TestCases")]


### PR DESCRIPTION
BoothBoundsRuleに対し以下の修正を行いました。
@sokuhatiku ロジックに問題がないかレビューお願いします。

#154 
ParticleSystemおよびTrailRendererのBoundsが設定値を変更した直後に再計算されないため、これらのチェック時にboundsを再計算する変更を入れました。
両方ともとてもハックなコードのため、より良い方法があれば指摘いただきたいです。

#148 
Vケットのフィードバックに従い、非表示オブジェクトに対してもBoundsをチェックする仕様に変更しました。

#149
計測結果の表示桁数が固定の為、指定した精度によっては制限内に入っているように見える問題がありました。以下のように設定値に応じて表示精度を変えるよう変更しました。

size,marginの設定値の精度に応じて表示を変更する仕様とする。(小数点以下が最も多い値+1桁)
例1）
```
size: Vector3(4f, 5f, 4f)
margin: 0.01f
```
→ marginの桁＋1で小数点以下3桁表示
![image](https://user-images.githubusercontent.com/46106857/63698117-2763b080-c859-11e9-8e5c-8defef20d9af.png)

例2）
```
size: Vector3(4f, 5f, 4.5f)
margin: 0f
```
→ size.zの桁＋1で小数点以下2桁表示
![image](https://user-images.githubusercontent.com/46106857/63698156-3b0f1700-c859-11e9-93ce-78c656fa53fc.png)
