### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ VitDeckは多人数で特定のルールに沿ったUnityのアセットを同�
 作業管理者が事前にテンプレートおよびチェック用のルールを構成した上で作業者に配布することを前提にしています。
 
 # インストール方法
-[最新のリリース](https://github.com/vkettools/VitDeck/releases/latest)をダウンロードし、VitDeckを使用したいUnityプロジェクトにzipファイル内のunitypackageをインポートしてください。
+[最新のリリース](https://github.com/vkettools/VitDeck/releases/latest)のunitypackageをダウンロードし、VitDeckを使用したいUnityプロジェクトにインポートしてください。
 正しくインポートされるとUnityのメニューバーに`VitDeck`が表示されます。
 
 # 各機能の使い方


### PR DESCRIPTION
1.0.0リリース直前で見つけた誤記の修正です。

1.0.0リリースブランチを既にプッシュしてしまっているので
この修正をマージ後にrelease/1.0.0-take2 を作成してtag`1.0.0`を移動し、再度リリース作業を行います。