### PR TITLE
Update release.bat

### DIFF
--- a/release.bat
+++ b/release.bat
@@ -1,13 +1,13 @@
 setlocal
 set BAT_LOG=%~dp0release.log
-echo Build VitDeck release files. > %BAT_LOG% 2>&1
-echo %date% %time% >> %BAT_LOG% 2>&1
+echo Build VitDeck release files. > "%BAT_LOG%" 2>&1
+echo %date% %time% >> "%BAT_LOG%" 2>&1
 if "%1"=="" (
  set /p VERSION="input VERSION:"
 ) else (
  set  VERSION=%1
 )
-echo VERSION: %VERSION% >> %BAT_LOG% 2>&1
+echo VERSION: %VERSION% >> "%BAT_LOG%" 2>&1
 set UNITY_PATH="C:\Program Files\Unity\Hub\Editor\2017.4.28f1\Editor\Unity.exe"
 set LOG_FILE="release-unity.log"
 set PACKAGE_NAME="VitDeck-%VERSION%.unitypackage"
@@ -15,7 +15,7 @@ set RELEASE_INFO_JSON="latest.json"
 set VITDECK_ROOT=Assets\VitDeck
 set RELEASE_PATH=Release\VitDeck
 
-echo Remove Test folder >> %BAT_LOG% 2>&1
+echo Remove Test folder >> "%BAT_LOG%" 2>&1
 call :DelFolder "VitDeck\%VITDECK_ROOT%\AssetGuardian\Tests" "%BAT_LOG%"
 call :DelFolder "VitDeck\%VITDECK_ROOT%\Exporter\Tests" "%BAT_LOG%"
 call :DelFolder "VitDeck\%VITDECK_ROOT%\Main\ValidatedExporter\Tests" "%BAT_LOG%"
@@ -25,20 +25,20 @@ call :DelFolder "VitDeck\%VITDECK_ROOT%\Utilities\Tests" "%BAT_LOG%"
 call :DelFolder "VitDeck\%VITDECK_ROOT%\Validator\Tests" "%BAT_LOG%"
 call :DelFolder "VitDeck\%VITDECK_ROOT%\TestUtilities" "%BAT_LOG%"
 
-echo Delete UserSettings.asset >> %BAT_LOG% 2>&1
+echo Delete UserSettings.asset >> "%BAT_LOG%" 2>&1
 del /s /q "VitDeck\%VITDECK_ROOT%\Config\UserSettings.asset"
 
-echo Copy documents >> %BAT_LOG% 2>&1
-copy /Y LICENSE VitDeck\%VITDECK_ROOT%\LICENSE.txt >> %BAT_LOG% 2>&1
-copy /Y releaseAssets\LICENSE.txt.meta VitDeck\%VITDECK_ROOT%\LICENSE.txt.meta >> %BAT_LOG% 2>&1
-copy /Y README.md VitDeck\%VITDECK_ROOT%\README.txt >> %BAT_LOG% 2>&1
-copy /Y releaseAssets\README.txt.meta VitDeck\%VITDECK_ROOT%\README.txt.meta >> %BAT_LOG% 2>&1
+echo Copy documents >> "%BAT_LOG%" 2>&1
+copy /Y LICENSE VitDeck\%VITDECK_ROOT%\LICENSE.txt >> "%BAT_LOG%" 2>&1
+copy /Y releaseAssets\LICENSE.txt.meta VitDeck\%VITDECK_ROOT%\LICENSE.txt.meta >> "%BAT_LOG%" 2>&1
+copy /Y README.md VitDeck\%VITDECK_ROOT%\README.txt >> "%BAT_LOG%" 2>&1
+copy /Y releaseAssets\README.txt.meta VitDeck\%VITDECK_ROOT%\README.txt.meta >> "%BAT_LOG%" 2>&1
 
 
-echo Mount >> %BAT_LOG% 2>&1
-subst Z: . >> %BAT_LOG% 2>&1
+echo Mount >> "%BAT_LOG%" 2>&1
+subst Z: . >> "%BAT_LOG%" 2>&1
 
-echo Export unitypackage >> %BAT_LOG% 2>&1
+echo Export unitypackage >> "%BAT_LOG%" 2>&1
 %UNITY_PATH%^
  -exportPackage %VITDECK_ROOT% %PACKAGE_NAME%^
  -projectPath "Z:\VitDeck"^
@@ -47,19 +47,19 @@ echo Export unitypackage >> %BAT_LOG% 2>&1
  -logfile %LOG_FILE%^
  -quit
 
-echo Generate json file >> %BAT_LOG% 2>&1
+echo Generate json file >> "%BAT_LOG%" 2>&1
 echo { > %RELEASE_INFO_JSON% 2>&1
 echo  "version": "%VERSION%", >> %RELEASE_INFO_JSON% 2>&1
 echo  "package_name": "VitDeck-%VERSION%.unitypackage", >> %RELEASE_INFO_JSON% 2>&1
 echo  "download_url": "https://github.com/vkettools/VitDeck/releases/download/%VERSION%/VitDeck-%VERSION%.unitypackage" >> %RELEASE_INFO_JSON% 2>&1
 echo } >> %RELEASE_INFO_JSON% 2>&1
 
-echo Move to Release folder >> %BAT_LOG% 2>&1
-mkdir %RELEASE_PATH% >> %BAT_LOG% 2>&1
-move .\VitDeck\%PACKAGE_NAME% %RELEASE_PATH% >> %BAT_LOG% 2>&1
-move %RELEASE_INFO_JSON% %RELEASE_PATH% >> %BAT_LOG% 2>&1
+echo Move to Release folder >> "%BAT_LOG%" 2>&1
+mkdir %RELEASE_PATH% >> "%BAT_LOG%" 2>&1
+move .\VitDeck\%PACKAGE_NAME% %RELEASE_PATH% >> "%BAT_LOG%" 2>&1
+move %RELEASE_INFO_JSON% %RELEASE_PATH% >> "%BAT_LOG%" 2>&1
 
-echo Unmount >> %BAT_LOG% 2>&1
+echo Unmount >> "%BAT_LOG%" 2>&1
 subst Z: /D
 
 exit /b


### PR DESCRIPTION
Fix #175
Release.batの修正です。
リポジトリのパスに空白が含まれている場合にエラーが出る問題に対応しました。

ローカルにてテスト済み。