### PR TITLE
GUI init: [InitializeOnLoadMethod] は Static メソッドでなければいけない。 OnEnableで代用

### DIFF
--- a/Assets/VitDeck/Main/ValidatedExporter/GUI/ValidatedExporterGUI.cs
+++ b/Assets/VitDeck/Main/ValidatedExporter/GUI/ValidatedExporterGUI.cs
@@ -76,7 +76,11 @@ namespace VitDeck.Main.ValidatedExporter.GUI
             window.Show();
         }
 
-        [InitializeOnLoadMethod]
+        private void OnEnable()
+        {
+            Init();
+        }
+
         private void Init()
         {
             settings = null;

--- a/Assets/VitDeck/Validator/GUI/ValidatorGUI.cs
+++ b/Assets/VitDeck/Validator/GUI/ValidatorGUI.cs
@@ -63,7 +63,10 @@ namespace VitDeck.Validator.GUI
             window.Show();
         }
 
-        [InitializeOnLoadMethod]
+        private void OnEnable()
+        {
+            Init();
+        }
         private void Init()
         {
             validationLog = "";


### PR DESCRIPTION
起動時の Non-Static Method エラーを解消するため