### PR TITLE
BoothRangeIndicatorのUnity2022での不具合対応

### DIFF
--- a/Packages/com.vitdeck.core/Validator/Runtime/BoundsIndicators/BoothRangeIndicator.cs
+++ b/Packages/com.vitdeck.core/Validator/Runtime/BoundsIndicators/BoothRangeIndicator.cs
@@ -1,10 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace VitDeck.Validator.BoundsIndicators
 {
-    [ExecuteInEditMode]
+    [ExecuteAlways]
     public class BoothRangeIndicator : MonoBehaviour, IBoothRoot
     {
         [System.NonSerialized] bool initialized = false;
@@ -24,7 +22,8 @@ namespace VitDeck.Validator.BoundsIndicators
 
         private void Token_Reset()
         {
-            SafeDestroy();
+            if(this)
+                SafeDestroy();
         }
 
         private void Update()


### PR DESCRIPTION
# 2022での不具合対応
Validator.Validateの`Undo.RevertAllInCurrentGroup`の動作が2022で変わった？
不具合というか、Undo.RevertAllInCurrentGroupの動作が正常に戻ってしまったというか。AddComponentしたのもRevertするようになった。

rootObjectにAssComponentしたBoothRangeIndicatorのOnDestoryが発火され、シーンから消えるためGizmoが残らない。
また、Removeした後にResetTokenのResetを発火すると自身が存在しないためAction発火タイミングで例外を吐きます。

VketToolsでは、もう一度BoothBoundsルールを発火することでGizmoを表示するように対応してます。

# やったこと
Unity2022ではUndo.RevertAllInCurrentGroupで消されるため、Token_Resetのタイミングで例外が発生しないように対応