### PR TITLE
MeshFilterLocalBoundProviderの不具合修正

### DIFF
--- a/Packages/com.vitdeck.core/Validator/Runtime/BoundsIndicators/MeshFilterLocalBoundProvider.cs
+++ b/Packages/com.vitdeck.core/Validator/Runtime/BoundsIndicators/MeshFilterLocalBoundProvider.cs
@@ -17,7 +17,7 @@ namespace VitDeck.Validator.BoundsIndicators
             {
                 if (!filter) return new Bounds();
 
-                var mesh = filter.mesh;
+                var mesh = filter.sharedMesh;
                 return mesh != null ? mesh.bounds : new Bounds();
             }
         }


### PR DESCRIPTION
MeshFilterLocalBoundProviderでmeshを生成してしまい、メモリリークが発生してしまっている。
その上でシーンを保存してしまうと別のメッシュとしてシーンに埋め込まれてしまう現象が発生する。